### PR TITLE
Support to set custom binding placeholder and custom binding engine

### DIFF
--- a/examples/postgresql_placeholder/main.go
+++ b/examples/postgresql_placeholder/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	sqlTemplate "github.com/NicklasWallgren/sqlTemplate/pkg"
+)
+
+func main() {
+	wd, _ := os.Getwd()
+	fs := os.DirFS(wd + "/examples/postgresql_placeholder/queries/users")
+
+	pgPlaceholder := func(_ any, index int) string { return fmt.Sprintf("$%d", index+1) }
+
+	sqlT := sqlTemplate.NewQueryTemplateEngine(sqlTemplate.WithPlaceholderFunc(pgPlaceholder))
+	if err := sqlT.Register("users", fs, ".tsql"); err != nil {
+		panic(err)
+	}
+
+	criteria := map[string]interface{}{"a": "a", "b": "b", "c": "c"}
+
+	tmpl, err := sqlT.ParseWithValuesFromMap("users", "multipleBinds", criteria)
+	if err != nil {
+		panic(err)
+	}
+
+	// nolint:forbidigo
+	fmt.Printf("query %v\n", tmpl.GetQuery())
+	// nolint:forbidigo
+	fmt.Printf("query parameters %v\n", tmpl.GetParams())
+}

--- a/examples/postgresql_placeholder/queries/users/users.tsql
+++ b/examples/postgresql_placeholder/queries/users/users.tsql
@@ -1,0 +1,8 @@
+{{define "multipleBinds"}}
+SELECT *
+FROM users
+WHERE TRUE
+  AND a={{bind .a}}
+  AND b={{bind .b}}
+  AND c={{bind .c}}
+{{end}}

--- a/pkg/template_engine_test.go
+++ b/pkg/template_engine_test.go
@@ -2,18 +2,20 @@ package pkg_test
 
 import (
 	"embed"
+	"fmt"
 	"testing"
 	"text/template"
 
 	"github.com/NicklasWallgren/sqlTemplate/pkg"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 //go:embed testdata/*.tsql
 var fs embed.FS // nolint: varnamelen
 
-func TestNewQueryTemplateEngine(t *testing.T) {
+func TestNewQueryTemplateEngine(_ *testing.T) {
 	pkg.NewQueryTemplateEngine()
 }
 
@@ -74,7 +76,88 @@ func TestQueryTemplateEngine_ParseWithValuesFromStruct(t *testing.T) {
 	criteria := searchCriteria{ID: 1, Order: "id"}
 
 	template, err := sqlT.ParseWithValuesFromStruct("users", "findById", criteria)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, "\n    SELECT *\n    FROM users\n    WHERE id=?\n    ORDER BY id\n", template.GetQuery())
 	assert.Equal(t, []any{1}, template.GetParams())
+}
+
+func getExtendedCriteria() map[string]any {
+	return map[string]interface{}{"a": "a", "b": "b", "c": "c"}
+}
+
+func getExpectedExtendedQuery(isPgBind bool) string {
+	expected := `
+SELECT *
+FROM users
+WHERE TRUE
+`
+	if isPgBind {
+		expected += `  AND a=$1
+  AND b=$2
+  AND c=$3
+`
+	} else {
+		expected += `  AND a=?
+  AND b=?
+  AND c=?
+`
+	}
+
+	return expected
+}
+
+func testExtendedParams(t *testing.T, params []any) {
+	t.Helper()
+	assert.Equal(t, 3, len(params), "wrong parameters length")
+	assert.Equal(t, "a", params[0], "parameter does not match")
+	assert.Equal(t, "b", params[1], "parameter does not match")
+	assert.Equal(t, "c", params[2], "parameter does not match")
+}
+
+func TestQueryTemplateEngine_ParseWithValuesFromMap2(t *testing.T) {
+	sqlT := pkg.NewQueryTemplateEngine(pkg.WithTemplateFunctions(template.FuncMap{}))
+
+	if err := sqlT.Register("users", fs, ".tsql"); err != nil {
+		t.Fatal()
+	}
+
+	template, err := sqlT.ParseWithValuesFromMap("users", "multipleBinds", getExtendedCriteria())
+	assert.Nil(t, err)
+
+	assert.Equal(t, getExpectedExtendedQuery(false), template.GetQuery())
+
+	testExtendedParams(t, template.GetParams())
+}
+
+func TestQueryTemplateEngine_ParseWithValuesFromMapCustomPlaceholder(t *testing.T) {
+	pgPlaceholder := func(_ any, index int) string { return fmt.Sprintf("$%d", index+1) }
+
+	sqlT := pkg.NewQueryTemplateEngine(pkg.WithPlaceholderFunc(pgPlaceholder))
+
+	if err := sqlT.Register("users", fs, ".tsql"); err != nil {
+		t.Fatal()
+	}
+
+	template, err := sqlT.ParseWithValuesFromMap("users", "multipleBinds", getExtendedCriteria())
+	require.Nil(t, err)
+
+	assert.Equal(t, getExpectedExtendedQuery(true), template.GetQuery(), "expected query failed")
+	testExtendedParams(t, template.GetParams())
+}
+
+func TestQueryTemplateEngine_ParseWithValuesFromMapCustomBindingEngine(t *testing.T) {
+	pgPlaceholder := func(_ any, index int) string { return fmt.Sprintf("$%d", index+1) }
+	bindingEninge := pkg.NewBindingEngine()
+	bindingEninge.SetPlaceholderFunc(pgPlaceholder)
+	sqlT := pkg.NewQueryTemplateEngine(pkg.WithBindingEngine(bindingEninge))
+
+	if err := sqlT.Register("users", fs, ".tsql"); err != nil {
+		t.Fatal()
+	}
+
+	template, err := sqlT.ParseWithValuesFromMap("users", "multipleBinds", getExtendedCriteria())
+	require.Nil(t, err)
+
+	assert.Equal(t, getExpectedExtendedQuery(true), template.GetQuery(), "expected query failed")
+	testExtendedParams(t, template.GetParams())
 }

--- a/pkg/testdata/users.tsql
+++ b/pkg/testdata/users.tsql
@@ -5,6 +5,15 @@
     {{if .Order}}ORDER BY {{.Order}}{{end}}
 {{end}}
 
+{{define "multipleBinds"}}
+SELECT *
+FROM users
+WHERE TRUE
+  AND a={{bind .a}}
+  AND b={{bind .b}}
+  AND c={{bind .c}}
+{{end}}
+
 {{define "findUsers"}}
     SELECT *
     FROM users


### PR DESCRIPTION
Add support to set custom binding placeholder and custom binding engine.
Actually the placeholder is hardcoded and is not compatible with PostgreSQL placeholder `$1, $2, etc`.

This pull request allow to use custom placeholder function and even custom binding engine.

Unit tests and example are added.

### Note

 I think that, conceptually, it is not to the the repository to handle parsing.
`func (r *repository) parse…` should be moved to the `queryTemplateEngine`, the repo should only manage the `FS`.

Maybe an other pull request ? :smiley: 
